### PR TITLE
Prefixed all attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Install with [Bower](http://bower.io)
 
 Include the script `qtip2` into your app and add `qtip2` as a module dependency to your app. Use the directive on the elements with the attribute `qtip`
 
-    <a href="/cool-stuff" qtip data-content="Text to appear in the tip">Hover me</a>
+    <a href="/cool-stuff" qtip="Text to appear in the tip">Hover me</a>
 
 List of attributes you can use:
 
-* `data-content`: Content that will appear in the tip
-* `data-title`: Title that will appear in the tip
-* `data-my`: position of the tip arrow - optionnal: default to `bottom center`
-* `data-at`: position of the tip - optionnal: default to `top center`
-* `data-class`: class to use on the tip - optionnal: default to `qtip`
+* `qtip-content` or `qtip`: Content that will appear in the tip
+* `qtip-title`: Title that will appear in the tip
+* `qtip-my`: position of the tip arrow - optionnal: default to `bottom center`
+* `qtip-at`: position of the tip - optionnal: default to `top center`
+* `qtip-class`: class to use on the tip - optionnal: default to `qtip`
 
 For more details about the options see the [Qtip2 documentation](http://qtip2.com/demos#section-positioning)

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ List of attributes you can use:
 * `qtip-my`: position of the tip arrow - optionnal: default to `bottom center`
 * `qtip-at`: position of the tip - optionnal: default to `top center`
 * `qtip-class`: class to use on the tip - optionnal: default to `qtip`
+* `qtip-visible`: a scope variable to trigger the visibillity from extern
 
 For more details about the options see the [Qtip2 documentation](http://qtip2.com/demos#section-positioning)

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "main": "qtip2.js",
   "dependencies": {
-    "jquery": "~2.0.3",
+    "jquery": "~1.11.1",
     "qtip2": "~2.2.0"
   }
 }

--- a/qtip2.js
+++ b/qtip2.js
@@ -34,9 +34,7 @@
           });
 
           if(attrs.qtipVisible) {
-//              var qt_api = $(element).qtip('api');
               scope.$watch('qtipVisible', function (newValue, oldValue) {
-                  console.log('new value!', newValue);
                   $(element).qtip('toggle', newValue);
               });
           }

--- a/qtip2.js
+++ b/qtip2.js
@@ -6,6 +6,9 @@
     .directive('qtip', function() {
       return {
         restrict: 'A',
+        scope : {
+            qtipVisible : '='
+        },
         link: function(scope, element, attrs) {
           var my = attrs.qtipMy || 'bottom center'
             , at = attrs.qtipAt || 'top center'
@@ -29,6 +32,14 @@
             },
             style: qtipClass
           });
+
+          if(attrs.qtipVisible) {
+//              var qt_api = $(element).qtip('api');
+              scope.$watch('qtipVisible', function (newValue, oldValue) {
+                  console.log('new value!', newValue);
+                  $(element).qtip('toggle', newValue);
+              });
+          }
         }
       }
     })

--- a/qtip2.js
+++ b/qtip2.js
@@ -7,16 +7,13 @@
       return {
         restrict: 'A',
         link: function(scope, element, attrs) {
-          var my = attrs.my || 'bottom center'
-            , at = attrs.at || 'top center'
-            , qtipClass = attrs.class || 'qtip'
-            , content
-
-          if (attrs.title) {
-            content = {'title': attrs.title, 'text': attrs.content}
-          }
-          else {
-            content = attrs.content
+          var my = attrs.qtipMy || 'bottom center'
+            , at = attrs.qtipAt || 'top center'
+            , qtipClass = attrs.qtipClass || 'qtip'
+            , content = attrs.qtipContent || attrs.qtip;
+        
+          if (attrs.qtipTitle) {
+            content = {'title': attrs.qtipTitle, 'text': attrs.qtip};
           }
 
           $(element).qtip({
@@ -31,7 +28,7 @@
               delay : 100
             },
             style: qtipClass
-          })
+          });
         }
       }
     })


### PR DESCRIPTION
Since it does not so much sense to take the class of the parent I prefixed all attributes. Additionally you now can write the content also directly to the qtip attribute.